### PR TITLE
Add TypeScript support, require color props

### DIFF
--- a/dist/progress-label.js
+++ b/dist/progress-label.js
@@ -17,9 +17,9 @@ module.exports = React.createClass({
     trackWidth: React.PropTypes.number,
     cornersWidth: React.PropTypes.number,
     progress: React.PropTypes.number,
-    fillColor: React.PropTypes.string,
-    trackColor: React.PropTypes.string,
-    progressColor: React.PropTypes.string
+    fillColor: React.PropTypes.string.isRequired,
+    trackColor: React.PropTypes.string.isRequired,
+    progressColor: React.PropTypes.string.isRequired
   },
 
   getDefaultProps: function getDefaultProps() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+import { Component, SVGAttributes } from 'react';
+
+export interface ProgressLabelProps extends SVGAttributes<ProgressLabel> {
+  size?: number,
+  startDegree?: number,
+  endDegree?: number,
+  progressWidth?: number,
+  trackWidth?: number,
+  cornersWidth?: number,
+  progress?: number,
+  fillColor: string,
+  trackColor: string,
+  progressColor: string
+}
+
+export default class ProgressLabel extends Component<ProgressLabelProps, void> {}

--- a/lib/progress-label.js
+++ b/lib/progress-label.js
@@ -11,9 +11,9 @@ module.exports = React.createClass({
     trackWidth: React.PropTypes.number,
     cornersWidth: React.PropTypes.number,
     progress: React.PropTypes.number,
-    fillColor: React.PropTypes.string,
-    trackColor: React.PropTypes.string,
-    progressColor: React.PropTypes.string
+    fillColor: React.PropTypes.string.isRequired,
+    trackColor: React.PropTypes.string.isRequired,
+    progressColor: React.PropTypes.string.isRequired
   },
 
   getDefaultProps() {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.2",
   "description": "progress label component",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "babel lib --out-dir dist & webpack -p",
     "start": "webpack-dev-server -c --port=7788",


### PR DESCRIPTION
Modify propTypes to require fillColor, trackColor and progressColor for which there are no defaultProps and without which the component will not render correctly.

Add TypeScript definition file for the component that reflects the updated propTypes.
